### PR TITLE
Remove legacy MoviePy support and pin to v2.2.1

### DIFF
--- a/main.py
+++ b/main.py
@@ -18,9 +18,7 @@ for _path in _VENV_CANDIDATES:
     if _path.exists() and str(_path) not in sys.path:
         sys.path.insert(0, str(_path))
         break
-
 from moviepy import CompositeVideoClip
-
 from utils.audio import load_audio
 from utils.slideshow import create_slideshow
 from utils.subtitles import (

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-moviepy
+moviepy==2.2.1
 Pillow


### PR DESCRIPTION
## Summary
- import MoviePy classes directly from the root package
- pin MoviePy dependency to 2.2.1

## Testing
- `pip install -r requirements.txt`
- `python main.py --help`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689232c9ebf4832b9d892b74d5bee122